### PR TITLE
Modified Default Element-wise benchmark to Fix Accuracy Bug

### DIFF
--- a/include/benchmarks/ckks/seal_ckks_element_wise_benchmark.h
+++ b/include/benchmarks/ckks/seal_ckks_element_wise_benchmark.h
@@ -22,7 +22,7 @@ public:
 
     static constexpr std::size_t DefaultPolyModulusDegree   = 8192;
     static constexpr std::size_t DefaultMultiplicativeDepth = 2;
-    static constexpr std::size_t DefaultCoeffModulusBits    = 40;
+    static constexpr std::size_t DefaultCoeffModulusBits    = 50;
     static constexpr std::size_t DefaultScaleBits           = DefaultCoeffModulusBits;
 
     enum : std::uint64_t


### PR DESCRIPTION
## Proposed changes

- Increased scale/coeff mod bits to fix intermittent accuracy issue when input is close to zero

## Types of changes

What types of changes does your code introduce to the HEBench SEAL Reference Backend?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hebench/backend-cpu-seal/blob/main/CONTRIBUTING.md) doc
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
